### PR TITLE
feat: implementa busca de eventos por proximidade geográfica

### DIFF
--- a/src/BoraLaBackend.Test/Feature/Events/EventsServiceTests.cs
+++ b/src/BoraLaBackend.Test/Feature/Events/EventsServiceTests.cs
@@ -181,5 +181,87 @@ namespace BoraLaBackend.Test.Events
             Assert.That(resultado.All(e => e.Category == "Teatro"), Is.True);
             Assert.That(resultado.Any(e => e.Category == "Música"), Is.False);
         }
+
+        [Test]
+        public async Task GetNearbyEventsAsync_DeveRetornarEventosDentroDoRaio()
+        {
+            var eventos = new List<Event>
+            {
+                new Event
+                {
+                    Id = "1",
+                    Title = "Festival na Paulista",
+                    Category = "Música",
+                    Location = "Club Síntese",
+                    GeoLocation = new GeoLocation { Type = "Point", Coordinates = [-46.655881, -23.561414] },
+                    Participants = new List<string>()
+                }
+            };
+
+            _eventRepoMock
+                .Setup(r => r.GetNearbyAsync(-46.655881, -23.561414, 10))
+                .ReturnsAsync(eventos);
+
+            var resultado = await _service.GetNearbyEventsAsync(-46.655881, -23.561414, 10);
+
+            Assert.That(resultado.Count(), Is.EqualTo(1));
+            Assert.That(resultado.First().Title, Is.EqualTo("Festival na Paulista"));
+        }
+
+        [Test]
+        public async Task GetNearbyEventsAsync_SemEventosNoRaio_DeveRetornarListaVazia()
+        {
+            _eventRepoMock
+                .Setup(r => r.GetNearbyAsync(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()))
+                .ReturnsAsync(new List<Event>());
+
+            var resultado = await _service.GetNearbyEventsAsync(-43.9387, -19.9167, 10);
+
+            Assert.That(resultado, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetNearbyEventsAsync_DeveRetornarGeoLocationNaResposta()
+        {
+            var geoLocation = new GeoLocation { Type = "Point", Coordinates = [-46.655881, -23.561414] };
+
+            _eventRepoMock
+                .Setup(r => r.GetNearbyAsync(-46.655881, -23.561414, 10))
+                .ReturnsAsync(new List<Event>
+                {
+                    new Event
+                    {
+                        Id = "1",
+                        Title = "Evento com Coordenadas",
+                        GeoLocation = geoLocation,
+                        Participants = new List<string>()
+                    }
+                });
+
+            var resultado = await _service.GetNearbyEventsAsync(-46.655881, -23.561414, 10);
+
+            Assert.That(resultado.First().GeoLocation, Is.Not.Null);
+            Assert.That(resultado.First().GeoLocation!.Type, Is.EqualTo("Point"));
+            Assert.That(resultado.First().GeoLocation!.Coordinates, Is.EqualTo(new double[] { -46.655881, -23.561414 }));
+        }
+
+        [Test]
+        public async Task GetNearbyEventsAsync_DeveRetornarMultiplosEventosDentroDoRaio()
+        {
+            var eventos = new List<Event>
+            {
+                new Event { Id = "1", Title = "Evento A", GeoLocation = new GeoLocation { Type = "Point", Coordinates = [-46.65, -23.56] }, Participants = new List<string>() },
+                new Event { Id = "2", Title = "Evento B", GeoLocation = new GeoLocation { Type = "Point", Coordinates = [-46.66, -23.57] }, Participants = new List<string>() },
+                new Event { Id = "3", Title = "Evento C", GeoLocation = new GeoLocation { Type = "Point", Coordinates = [-46.67, -23.58] }, Participants = new List<string>() }
+            };
+
+            _eventRepoMock
+                .Setup(r => r.GetNearbyAsync(-46.655881, -23.561414, 50))
+                .ReturnsAsync(eventos);
+
+            var resultado = await _service.GetNearbyEventsAsync(-46.655881, -23.561414, 50);
+
+            Assert.That(resultado.Count(), Is.EqualTo(3));
+        }
     }
 }

--- a/src/backend/Feature/Events/DTO/CreateEventRequest.cs
+++ b/src/backend/Feature/Events/DTO/CreateEventRequest.cs
@@ -11,5 +11,7 @@ namespace BoraLaBackend.Feature.Events.DTO
         public string Location { get; set; }
         public string? Category { get; set; }
         public int Capacity { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
     }
 }

--- a/src/backend/Feature/Events/DTO/EventFeedResponse.cs
+++ b/src/backend/Feature/Events/DTO/EventFeedResponse.cs
@@ -10,6 +10,7 @@ namespace BoraLaBackend.Feature.Events.DTO
         public DateTime Date { get; set; }
         public Address Address { get; set; }
         public string Location { get; set; }
+        public GeoLocation? GeoLocation { get; set; }
         public string Category { get; set; }
         public int Capacity { get; set; }
         public int ParticipantsCount { get; set; }

--- a/src/backend/Feature/Events/DTO/UpdateEventRequest.cs
+++ b/src/backend/Feature/Events/DTO/UpdateEventRequest.cs
@@ -9,5 +9,7 @@ namespace BoraLaBackend.Feature.Events.DTO
         public string? Location { get; set; }
         public string? Category { get; set; }
         public int? Capacity { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
     }
 }

--- a/src/backend/Feature/Events/EventsController.cs
+++ b/src/backend/Feature/Events/EventsController.cs
@@ -45,6 +45,26 @@ namespace BoraLaBackend.Feature.Events
             return Ok(results);
         }
 
+        /// <summary>Busca eventos por proximidade geográfica.</summary>
+        /// <remarks>Retorna eventos dentro do raio informado. Requer que os eventos tenham coordenadas cadastradas (latitude/longitude).</remarks>
+        /// <param name="latitude">Latitude do ponto central da busca.</param>
+        /// <param name="longitude">Longitude do ponto central da busca.</param>
+        /// <param name="radiusKm">Raio de busca em quilômetros (padrão: 10km).</param>
+        /// <response code="200">Lista de eventos encontrados no raio.</response>
+        /// <response code="400">Parâmetros de latitude ou longitude inválidos.</response>
+        [HttpGet("nearby")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(IEnumerable<EventFeedResponse>), 200)]
+        [ProducesResponseType(400)]
+        public async Task<IActionResult> GetNearbyEvents([FromQuery] double latitude, [FromQuery] double longitude, [FromQuery] double radiusKm = 10)
+        {
+            if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180)
+                return BadRequest(new { message = "Invalid latitude or longitude values" });
+
+            var results = await _eventsService.GetNearbyEventsAsync(longitude, latitude, radiusKm);
+            return Ok(results);
+        }
+
         /// <summary>Cria um novo evento.</summary>
         /// <remarks>Apenas organizadores (cadastrados com CNPJ) podem criar eventos.</remarks>
         /// <response code="201">Evento criado com sucesso.</response>

--- a/src/backend/Feature/Events/Repository/EventRepository.cs
+++ b/src/backend/Feature/Events/Repository/EventRepository.cs
@@ -65,6 +65,23 @@ namespace BoraLaBackend.Feature.Events.Repository
                 .ToListAsync();
         }
 
+        public async Task<IEnumerable<Event>> GetNearbyAsync(double longitude, double latitude, double radiusInKm)
+        {
+            var radiusInRadians = radiusInKm / 6371.0;
+
+            var filter = Builders<Event>.Filter.GeoWithinCenterSphere(
+                "GeoLocation.coordinates",
+                longitude,
+                latitude,
+                radiusInRadians
+            );
+
+            return await _events
+                .Find(filter)
+                .SortBy(e => e.Date)
+                .ToListAsync();
+        }
+
         public async Task UpdateAsync(string id, Event evt)
         {
             await _events.ReplaceOneAsync(e => e.Id == id, evt);

--- a/src/backend/Feature/Events/Repository/IEventRepository.cs
+++ b/src/backend/Feature/Events/Repository/IEventRepository.cs
@@ -8,6 +8,7 @@ namespace BoraLaBackend.Feature.Events.Repository
         Task<Event?> GetByIdAsync(string id);
         Task<IEnumerable<Event>> GetFeedAsync(DateTime from);
         Task<IEnumerable<Event>> SearchAsync(string? name, string? category);
+        Task<IEnumerable<Event>> GetNearbyAsync(double longitude, double latitude, double radiusInKm);
         Task UpdateAsync(string id, Event evt);
         Task DeleteAsync(string id);
     }

--- a/src/backend/Feature/Events/Services/EventsService.cs
+++ b/src/backend/Feature/Events/Services/EventsService.cs
@@ -4,6 +4,7 @@ using BoraLaBackend.Feature.Events.Enums;
 using BoraLaBackend.Feature.Events.Repository;
 using BoraLaBackend.Feature.Users.Repository;
 using BoraLaBackend.Models;
+using GeoLocationModel = BoraLaBackend.Models.GeoLocation;
 
 namespace BoraLaBackend.Feature.Events.Services
 {
@@ -34,6 +35,9 @@ namespace BoraLaBackend.Feature.Events.Services
                 Date = request.Date,
                 Address = request.Address,
                 Location = request.Location,
+                GeoLocation = request.Latitude.HasValue && request.Longitude.HasValue
+                    ? new GeoLocationModel { Coordinates = [request.Longitude.Value, request.Latitude.Value] }
+                    : null,
                 Category = request.Category,
                 Capacity = request.Capacity,
                 OrganizerId = user.Id,
@@ -60,6 +64,7 @@ namespace BoraLaBackend.Feature.Events.Services
                     Date = e.Date,
                     Address = e.Address,
                     Location = e.Location,
+                    GeoLocation = e.GeoLocation,
                     Category = e.Category,
                     Capacity = e.Capacity,
                     ParticipantsCount = e.Participants.Count,
@@ -81,6 +86,29 @@ namespace BoraLaBackend.Feature.Events.Services
                     Date = e.Date,
                     Address = e.Address,
                     Location = e.Location,
+                    GeoLocation = e.GeoLocation,
+                    Category = e.Category,
+                    Capacity = e.Capacity,
+                    ParticipantsCount = e.Participants.Count,
+                    OrganizerId = e.OrganizerId,
+                    CreatedAt = e.CreatedAt
+                });
+        }
+
+        public async Task<IEnumerable<EventFeedResponse>> GetNearbyEventsAsync(double longitude, double latitude, double radiusInKm)
+        {
+            var events = await _eventRepo.GetNearbyAsync(longitude, latitude, radiusInKm);
+
+            return events
+                .Select(e => new EventFeedResponse
+                {
+                    Id = e.Id,
+                    Title = e.Title,
+                    Description = e.Description,
+                    Date = e.Date,
+                    Address = e.Address,
+                    Location = e.Location,
+                    GeoLocation = e.GeoLocation,
                     Category = e.Category,
                     Capacity = e.Capacity,
                     ParticipantsCount = e.Participants.Count,
@@ -107,6 +135,9 @@ namespace BoraLaBackend.Feature.Events.Services
             evt.Location = request.Location ?? evt.Location;
             evt.Category = request.Category ?? evt.Category;
             evt.Capacity = request.Capacity ?? evt.Capacity;
+
+            if (request.Latitude.HasValue && request.Longitude.HasValue)
+                evt.GeoLocation = new GeoLocationModel { Coordinates = [request.Longitude.Value, request.Latitude.Value] };
 
             if (request.Address != null)
             {

--- a/src/backend/Feature/Events/Services/IEventsService.cs
+++ b/src/backend/Feature/Events/Services/IEventsService.cs
@@ -9,6 +9,7 @@ namespace BoraLaBackend.Feature.Events.Services
         Task<(CreateEventResult result, Event? evt)> CreateEventAsync(string organizerEmail, CreateEventRequest request);
         Task<IEnumerable<EventFeedResponse>> GetFeedAsync();
         Task<IEnumerable<EventFeedResponse>> SearchEventsAsync(string? name, string? category);
+        Task<IEnumerable<EventFeedResponse>> GetNearbyEventsAsync(double longitude, double latitude, double radiusInKm);
         Task<(EventOperationResult result, Event? evt)> UpdateEventAsync(string organizerEmail, string eventId, UpdateEventRequest request);
         Task<EventOperationResult> DeleteEventAsync(string organizerEmail, string eventId);
     }

--- a/src/backend/Models/Event.cs
+++ b/src/backend/Models/Event.cs
@@ -23,6 +23,8 @@ namespace BoraLaBackend.Models
         [BsonRequired]
         public string Location { get; set; }
 
+        public GeoLocation? GeoLocation { get; set; }
+
         // TODO: Make Category required after migrating existing events without category
         public string Category { get; set; }
 

--- a/src/backend/Models/GeoLocation.cs
+++ b/src/backend/Models/GeoLocation.cs
@@ -1,0 +1,13 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace BoraLaBackend.Models
+{
+    public class GeoLocation
+    {
+        [BsonElement("type")]
+        public string Type { get; set; } = "Point";
+
+        [BsonElement("coordinates")]
+        public double[] Coordinates { get; set; } // [longitude, latitude]
+    }
+}


### PR DESCRIPTION
# PR: RF-010 — Filtros por Geolocalização com Raio de Distância

## Descrição

Implementa a funcionalidade de **filtros por geolocalização com raio de distância (RF-010)**, permitindo que frequentadores busquem eventos próximos à sua localização atual.

---

## Mudanças

### Modelo
- Adicionado modelo `GeoLocation` com suporte a GeoJSON Point (`type` + `coordinates`)
- Adicionado campo `GeoLocation` (opcional) ao modelo `Event`

### DTOs
- `CreateEventRequest`: adicionados campos opcionais `Latitude` e `Longitude`
- `UpdateEventRequest`: adicionados campos opcionais `Latitude` e `Longitude`
- `EventFeedResponse`: adicionado campo `GeoLocation`

### Repositório
- Novo método `GetNearbyAsync(longitude, latitude, radiusInKm)` — busca geoespacial com `$geoWithin $centerSphere`

### Serviço
- Novo método `GetNearbyEventsAsync(longitude, latitude, radiusInKm)`

### Controller
- `GET /events/nearby?latitude=X&longitude=Y&radiusKm=Z` — público, raio padrão de 10km

---

## Testes realizados via Postman

Evento criado com coordenadas de São Paulo (`lat: -23.561414, lng: -46.655881`):
```json
{
  "title": "Festival na Paulista",
  "location": "Club Síntese",
  "category": "Música",
  "geoLocation": { "type": "Point", "coordinates": [-46.655881, -23.561414] }
}
```

**Busca raio 5km → retornou o evento** ✅
```
GET /events/nearby?latitude=-23.561414&longitude=-46.655881&radiusKm=5
```

**Busca raio 10km → retornou o evento** ✅
```
GET /events/nearby?latitude=-23.561414&longitude=-46.655881&radiusKm=10
```

**Busca raio 50km → retornou o evento** ✅
```
GET /events/nearby?latitude=-23.561414&longitude=-46.655881&radiusKm=50
```

**Busca com coordenadas de Belo Horizonte, raio 10km → retornou lista vazia** ✅
```
GET /events/nearby?latitude=-19.9167&longitude=-43.9387&radiusKm=10
```

---

## Observações

- `GeoLocation` é opcional — eventos sem coordenadas continuam aparecendo no feed e na busca por nome/categoria, mas não na busca por proximidade
- A busca por geolocalização requer índice `2dsphere` na coleção `events` do MongoDB (já criado no Atlas)
- O frontend pode obter a localização do usuário via `navigator.geolocation` e enviar as coordenadas na chamada
