### PR TITLE
swagger comments

### DIFF
--- a/src/backend/BoraLaBackend.csproj
+++ b/src/backend/BoraLaBackend.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="JWT" Version="11.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/backend/Feature/Authentication/AuthController.cs
+++ b/src/backend/Feature/Authentication/AuthController.cs
@@ -47,7 +47,7 @@ namespace BoraLaBackend.Feature.Authentication
                 return BadRequest(new
                 {
                     code = "MISSING_CREDENTIALS",
-                    message = "E-mail, senha e a identificação do app são obrigatórios."
+                    message = "E-mail, senha e a identificaï¿½ï¿½o do app sï¿½o obrigatï¿½rios."
                 });
             }
 
@@ -62,7 +62,7 @@ namespace BoraLaBackend.Feature.Authentication
                     ErrorMessageCode.INVALID_HEADER => BadRequest(new { message = name }),
                     ErrorMessageCode.INVALID_BODY => UnprocessableEntity(),
                     ErrorMessageCode.NOT_FOUNDED => NotFound(),
-                    ErrorMessageCode.UNAUTHORIZED => Unauthorized(new { code = "INVALID_CREDENTIALS", message = "Credenciais inválidas, verifique e tente novamente." }),
+                    ErrorMessageCode.UNAUTHORIZED => Unauthorized(new { code = "INVALID_CREDENTIALS", message = "Credenciais invï¿½lidas, verifique e tente novamente." }),
                     _ => StatusCode(500)
                 };
 

--- a/src/backend/Feature/Authentication/AuthController.cs
+++ b/src/backend/Feature/Authentication/AuthController.cs
@@ -47,7 +47,7 @@ namespace BoraLaBackend.Feature.Authentication
                 return BadRequest(new
                 {
                     code = "MISSING_CREDENTIALS",
-                    message = "E-mail, senha e a identifica��o do app s�o obrigat�rios."
+                    message = "E-mail, senha e a identificação do app são obrigatórios."
                 });
             }
 

--- a/src/backend/Feature/Comments/CommentsController.cs
+++ b/src/backend/Feature/Comments/CommentsController.cs
@@ -26,15 +26,10 @@ public class CommentsController(ICommentService service): ControllerBase
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> Create(
-        [FromRoute] string eventId,
-        [FromBody] CreateCommentDto dto)
+    public async Task<IActionResult> Create([FromBody] CreateCommentDto dto)
     {
-        if (dto.EventId != eventId)
-            return BadRequest("EventId inconsistente.");
-
         var created = await _service.CreateAsync(dto);
-        return CreatedAtAction(nameof(GetByEvent), new { eventId }, created);
+        return CreatedAtAction(nameof(GetByEvent), new { eventId = dto.EventId }, created);
     }
 
     // POST comments/id

--- a/src/backend/Feature/Events/EventsController.cs
+++ b/src/backend/Feature/Events/EventsController.cs
@@ -153,7 +153,7 @@ namespace BoraLaBackend.Feature.Events
             };
         }
 
-        /// <summary>cCurte um evento</summary>
+        /// <summary>Curte um evento</summary>
         /// <remarks>Apenas o organizador que criou o evento pode excluí-lo.</remarks>
         [HttpPost("{eventId}/like")]
         public async Task<IActionResult> ToggleLike(string eventId)

--- a/src/backend/Program.cs
+++ b/src/backend/Program.cs
@@ -12,8 +12,11 @@ using BoraLaBackend.Shared.Utils;
 using BoraLaBackend.Shared.Utils.Interfaces;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using MongoDB.Driver;
 using BoraLaBackend.Feature.Comments.Repositories;
+using BoraLaBackend.Feature.Comments.Services;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,10 +27,49 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "BoraLaBackend", Version = "v1" });
+
+    c.TagActionsBy(api =>
+    {
+        if (api.ActionDescriptor is Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor desc)
+        {
+            if (desc.ControllerName == "Users" && desc.ActionName == "Register")
+                return new[] { "Auth" };
+            return new[] { desc.ControllerName };
+        }
+        return new[] { api.GroupName ?? "default" };
+    });
+
+    c.DocumentFilter<TagOrderDocumentFilter>();
+
     var xmlFile = $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}.xml";
     var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
     c.IncludeXmlComments(xmlPath);
 
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Cole o token aqui (sem o prefixo 'Bearer')"
+    });
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
 });
 
 // Configure MongoDB
@@ -53,6 +95,7 @@ builder.Services.AddScoped<IUsersService, UsersService>();
 builder.Services.AddScoped<IEventRepository, EventRepository>();
 builder.Services.AddScoped<IEventsService, EventsService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<ICommentService, CommentService>();
 builder.Services.AddScoped<IEventLikeRepository, EventLikeRepository>();
 
 // Helpers
@@ -108,7 +151,7 @@ builder.Services.AddAuthentication(options =>
 var app = builder.Build();
 
 app.UseSwagger();
-app.UseSwaggerUI();
+app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "BoraLaBackend v1"));
 
 if (!app.Environment.IsDevelopment())
 {
@@ -122,3 +165,18 @@ app.MapControllers();
 app.MapFallback(() => Results.NotFound());
 
 app.Run();
+
+public class TagOrderDocumentFilter : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        swaggerDoc.Tags = new List<OpenApiTag>
+        {
+            new OpenApiTag { Name = "Auth" },
+            new OpenApiTag { Name = "Users" },
+            new OpenApiTag { Name = "Events" },
+            new OpenApiTag { Name = "Comments" },
+            new OpenApiTag { Name = "Health" }
+        };
+    }
+}

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -44,21 +44,71 @@ A documentação esta disponível [neste endereço](https://bora-la-eventos-api-
 
 ### Testando a aplicação
 
-O ponto de entrada da aplicação é o endpoint de `/auth/pré-login`. Utilize os parâmetros a seguir para gerar um token de aplicação:
-```Json
+O fluxo completo de autenticação exige **4 etapas** na ordem abaixo. Pular qualquer etapa resultará em erro.
+
+---
+
+#### Etapa 1 — Registrar um usuário
+
+Antes de qualquer login, é necessário cadastrar um usuário via `POST /users`:
+
+```json
 {
-  "clienId": "bora_la_api",
-  "clientSecret": "9eb71ab7420eb452a22787ca4fab501b" 
+  "name": "Seu Nome",
+  "document": "12345678909",
+  "email": "usuario@email.com",
+  "password": "Senha@123"
 }
 ```
-Uma vez gerado o token, adicione ao header da request para acessar os demais endpoints
 
-**Importante**
-1. O token de aplicação fornece acesso ao fluxo de __criação__ e __login do usuário__. Os endpoints pós login precisam do token de usuário, gerado no `/auth/login`
+> Use um CPF válido (11 dígitos) para usuário comum ou CNPJ válido (14 dígitos) para organizador.
 
-2. No endpoint de login é necessário adicionar um campo a mais no header: `x-request-id` que é usado na criação do token. Inicialmente, estamos usando o mesmo valor do `clientId` mas deverá ser substituído em breve por um valor inerente à aplicação.
+---
+
+#### Etapa 2 — Gerar o token de aplicação (pre-login)
+
+Chame `POST /auth/pre-login` com as credenciais da aplicação:
+
+```json
+{
+  "clientID": "bora_la_api",
+  "clientSecret": "9eb71ab7420eb452a22787ca4fab501b"
+}
+```
+
+Copie o `token` retornado. No Swagger, clique em **Authorize** e cole o token **sem** o prefixo `Bearer `.
+
+> Este token de aplicação expira em **20 minutos** e dá acesso apenas ao endpoint de login.
+
+---
+
+#### Etapa 3 — Fazer login
+
+Com o token de aplicação no Authorize, chame `POST /auth/login`:
+
+- Header `x-request-id`: `bora_la_api`
+- Body:
+
+```json
+{
+  "email": "usuario@email.com",
+  "password": "Senha@123"
+}
+```
+
+Copie o `token` retornado no campo `token` da resposta.
+
+---
+
+#### Etapa 4 — Autorizar com o token de usuário
+
+No Swagger, clique em **Authorize** novamente e substitua pelo novo token (sem o prefixo `Bearer `).
+
+> Este token de usuário expira em **1 hora**. Todos os endpoints protegidos exigem este token.
+
+---
 
 ### Tipos de Usuários
-A Aplicação da suporte a dois tipos de usuários: 
+A aplicação suporta dois tipos de usuários:
 - `user`: Usuário simples, capaz de visualizar o conteúdo da aplicação, interagir com eventos (likes e comentários), etc.
-- `organizer`: Usuário criador de eventos. Possui os mesmos acesso de um `user` acrescido da criação de gerenciamento de eventos
+- `organizer`: Usuário criador de eventos. Possui os mesmos acessos de um `user` acrescido da criação e gerenciamento de eventos. Deve ser cadastrado com CNPJ.


### PR DESCRIPTION
### O que foi alterado
#### Correções de bugs
- `CommentsController`: corrigido bug em `POST /comments` onde o parâmetro `eventId` era lido via `[FromRoute]` mas a rota não possuía `{eventId}`, causando erro 400 em todas as chamadas
- `Program.cs`: adicionado registro do `ICommentService` no container de injeção de dependência, que estava ausente e causava erro 500 nos endpoints de comentários

#### Swagger
- Adicionado botão **Authorize** com suporte a JWT Bearer, permitindo autenticação diretamente pelo Swagger UI
- Endpoint `POST /users` (registro) movido para o grupo **Auth** no Swagger, pois faz parte do fluxo de autenticação
- Definida ordem dos grupos: **Auth → Users → Events → Comments → Health**
- Downgrade do `Swashbuckle.AspNetCore` de `10.1.7` para `6.9.0` por incompatibilidade da versão 10.x com o Swagger UI (gerava spec `openapi: 3.0.4` não suportado)

#### README
- Reescrita da seção de testes com fluxo dividido em **4 etapas numeradas**, deixando explícito que o registro precisa acontecer antes do login
- Corrigido typo `clienId` → `clientID` no payload de exemplo
- Adicionadas informações sobre tempo de expiração dos tokens (app token: 20min, user token: 1h)
- Adicionadas instruções sobre o botão **Authorize** no Swagger

Print swagger: 
<img width="1694" height="1257" alt="image" src="https://github.com/user-attachments/assets/81ce299c-351d-4e93-b0a3-3de901ac7be3" />
