### PR TITLE
fix: using user ID as token JWT

### DIFF
--- a/src/backend/Feature/Authentication/Services/AuthService.cs
+++ b/src/backend/Feature/Authentication/Services/AuthService.cs
@@ -59,7 +59,7 @@ namespace BoraLaBackend.Feature.Authentication.Services
       bool isValidPassword = _pass.Check(password, usr.Password);
       if (!isValidPassword) return AuthResults.Unauthorized;
 
-      string token = _jwtService.GenerateToken(id, email, usr.TokenVersion);
+      string token = _jwtService.GenerateToken(id, usr.Id, usr.Email, usr.TokenVersion);
 
       var userResponse = new UserResponse
       {
@@ -84,10 +84,10 @@ namespace BoraLaBackend.Feature.Authentication.Services
     {
         var payload = decoder.DecodeToObject<Dictionary<string, object>>(purgedToken, _config["Auth:ServerSecret"], verify: true);
 
-        if (payload != null && payload.TryGetValue("email", out var emailObj))
+        if (payload != null && payload.TryGetValue("sub", out var subObj))
         {
-            var email = emailObj.ToString();
-            var user = await _usrRepository.GetByEmailAsync(email);
+            var userId = subObj.ToString();
+            var user = await _usrRepository.GetByIdAsync(userId!);
 
             if (user != null)
             {

--- a/src/backend/Feature/Events/EventsController.cs
+++ b/src/backend/Feature/Events/EventsController.cs
@@ -31,10 +31,10 @@ namespace BoraLaBackend.Feature.Events
         [HttpGet("mine")]
         public async Task<IActionResult> GetMyEvents()
         {
-            var email = User.FindFirst("sub")?.Value;
-            if (string.IsNullOrEmpty(email)) return Unauthorized();
+            var userId = User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
 
-            var events = await _eventsService.GetMyEventsAsync(email);
+            var events = await _eventsService.GetMyEventsAsync(userId);
             return Ok(events);
         }
 
@@ -97,11 +97,11 @@ namespace BoraLaBackend.Feature.Events
         [ProducesResponseType(404)]
         public async Task<IActionResult> CreateEvent([FromBody] CreateEventRequest request)
         {
-            var email = User.FindFirst("sub")?.Value;
-            if (string.IsNullOrEmpty(email))
+            var userId = User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 
-            var (result, evt) = await _eventsService.CreateEventAsync(email, request);
+            var (result, evt) = await _eventsService.CreateEventAsync(userId, request);
 
             return result switch
             {
@@ -126,11 +126,11 @@ namespace BoraLaBackend.Feature.Events
         [ProducesResponseType(404)]
         public async Task<IActionResult> UpdateEvent(string id, [FromBody] UpdateEventRequest request)
         {
-            var email = User.FindFirst("sub")?.Value;
-            if (string.IsNullOrEmpty(email))
+            var userId = User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 
-            var (result, evt) = await _eventsService.UpdateEventAsync(email, id, request);
+            var (result, evt) = await _eventsService.UpdateEventAsync(userId, id, request);
 
             return result switch
             {
@@ -156,11 +156,11 @@ namespace BoraLaBackend.Feature.Events
         [ProducesResponseType(404)]
         public async Task<IActionResult> DeleteEvent(string id)
         {
-            var email = User.FindFirst("sub")?.Value;
-            if (string.IsNullOrEmpty(email))
+            var userId = User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 
-            var result = await _eventsService.DeleteEventAsync(email, id);
+            var result = await _eventsService.DeleteEventAsync(userId, id);
 
             return result switch
             {

--- a/src/backend/Feature/Events/Services/EventsService.cs
+++ b/src/backend/Feature/Events/Services/EventsService.cs
@@ -20,9 +20,9 @@ namespace BoraLaBackend.Feature.Events.Services
             _likeRepository = likeRepository;
         }
 
-        public async Task<(CreateEventResult result, Event? evt)> CreateEventAsync(string organizerEmail, CreateEventRequest request)
+        public async Task<(CreateEventResult result, Event? evt)> CreateEventAsync(string organizerId, CreateEventRequest request)
         {
-            var user = await _userRepo.GetByEmailAsync(organizerEmail);
+            var user = await _userRepo.GetByIdAsync(organizerId);
             if (user == null)
                 return (CreateEventResult.UserNotFound, null);
 
@@ -57,12 +57,9 @@ namespace BoraLaBackend.Feature.Events.Services
             return (CreateEventResult.Success, created);
         }
 
-        public async Task<IEnumerable<EventFeedResponse>> GetMyEventsAsync(string organizerEmail)
+        public async Task<IEnumerable<EventFeedResponse>> GetMyEventsAsync(string organizerId)
         {
-            var user = await _userRepo.GetByEmailAsync(organizerEmail);
-            if (user == null) return [];
-
-            var events = await _eventRepo.GetByOrganizerIdAsync(user.Id);
+            var events = await _eventRepo.GetByOrganizerIdAsync(organizerId);
 
             return events.Select(e => new EventFeedResponse
             {
@@ -153,17 +150,13 @@ namespace BoraLaBackend.Feature.Events.Services
                     CreatedAt = e.CreatedAt
                 });
         }
-        public async Task<(EventOperationResult result, Event? evt)> UpdateEventAsync(string organizerEmail, string eventId, UpdateEventRequest request)
+        public async Task<(EventOperationResult result, Event? evt)> UpdateEventAsync(string organizerId, string eventId, UpdateEventRequest request)
         {
-            var user = await _userRepo.GetByEmailAsync(organizerEmail);
-            if (user == null)
-                return (EventOperationResult.UserNotFound, null);
-
             var evt = await _eventRepo.GetByIdAsync(eventId);
             if (evt == null)
                 return (EventOperationResult.EventNotFound, null);
 
-            if (evt.OrganizerId != user.Id)
+            if (evt.OrganizerId != organizerId)
                 return (EventOperationResult.NotTheOrganizer, null);
 
             evt.Title = request.Title ?? evt.Title;
@@ -190,17 +183,13 @@ namespace BoraLaBackend.Feature.Events.Services
             return (EventOperationResult.Success, evt);
         }
 
-        public async Task<EventOperationResult> DeleteEventAsync(string organizerEmail, string eventId)
+        public async Task<EventOperationResult> DeleteEventAsync(string organizerId, string eventId)
         {
-            var user = await _userRepo.GetByEmailAsync(organizerEmail);
-            if (user == null)
-                return EventOperationResult.UserNotFound;
-
             var evt = await _eventRepo.GetByIdAsync(eventId);
             if (evt == null)
                 return EventOperationResult.EventNotFound;
 
-            if (evt.OrganizerId != user.Id)
+            if (evt.OrganizerId != organizerId)
                 return EventOperationResult.NotTheOrganizer;
 
             await _eventRepo.DeleteAsync(eventId);

--- a/src/backend/Feature/Events/Services/IEventsService.cs
+++ b/src/backend/Feature/Events/Services/IEventsService.cs
@@ -6,14 +6,14 @@ namespace BoraLaBackend.Feature.Events.Services
 {
     public interface IEventsService
     {
-        Task<(CreateEventResult result, Event? evt)> CreateEventAsync(string organizerEmail, CreateEventRequest request);
+        Task<(CreateEventResult result, Event? evt)> CreateEventAsync(string organizerId, CreateEventRequest request);
         Task<IEnumerable<EventFeedResponse>> GetFeedAsync();
-        Task<IEnumerable<EventFeedResponse>> GetMyEventsAsync(string organizerEmail);
+        Task<IEnumerable<EventFeedResponse>> GetMyEventsAsync(string organizerId);
         Task<EventFeedResponse?> GetEventByIdAsync(string id);
         Task<IEnumerable<EventFeedResponse>> SearchEventsAsync(string? name, string? category);
         Task<IEnumerable<EventFeedResponse>> GetNearbyEventsAsync(double longitude, double latitude, double radiusInKm);
-        Task<(EventOperationResult result, Event? evt)> UpdateEventAsync(string organizerEmail, string eventId, UpdateEventRequest request);
-        Task<EventOperationResult> DeleteEventAsync(string organizerEmail, string eventId);
+        Task<(EventOperationResult result, Event? evt)> UpdateEventAsync(string organizerId, string eventId, UpdateEventRequest request);
+        Task<EventOperationResult> DeleteEventAsync(string organizerId, string eventId);
         Task ToggleLikeAsync(string userId, string eventId);
         Task<int> CountLikesAsync(string eventId);
     }

--- a/src/backend/Shared/Security/Interfaces/IJwtService.cs
+++ b/src/backend/Shared/Security/Interfaces/IJwtService.cs
@@ -4,7 +4,7 @@ namespace BoraLaBackend.Shared.Security
     public record ValidateTokenReturnProps(string Jti, DateTime Date);
     public interface IJwtService
     {
-        public string GenerateToken(string appId, string? email, int? tokenVersion = null);
+        public string GenerateToken(string appId, string? userId, string? email = null, int? tokenVersion = null);
 
         public bool ValidateToken(string token);
 

--- a/src/backend/Shared/Security/JwtService.cs
+++ b/src/backend/Shared/Security/JwtService.cs
@@ -28,11 +28,11 @@ namespace BoraLaBackend.Shared.Security
             _decoder = decoder;
         }
 
-        public string GenerateToken(string appId, string? email, int? tokenVersion = null)
+        public string GenerateToken(string appId, string? userId, string? email = null, int? tokenVersion = null)
         {
-            var payload = email == null
+            var payload = userId == null
                 ? CreateAppPayload(appId)
-                : CreateUserPayload(email, appId, tokenVersion ?? 0);
+                : CreateUserPayload(userId, email ?? "", appId, tokenVersion ?? 0);
 
             return _encoder.Encode(payload, _secretKey);
         }
@@ -107,13 +107,13 @@ namespace BoraLaBackend.Shared.Security
         { "iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds() }
      };
 
-        private static Dictionary<string, object> CreateUserPayload(string email, string appId, int tokenVersion)
+        private static Dictionary<string, object> CreateUserPayload(string userId, string email, string appId, int tokenVersion)
         {
             return new()
             {
                 { "jti", Guid.NewGuid().ToString() },
+                { "sub", userId },
                 { "email", email },
-                { "sub", email },
                 { "app_id", appId },
                 { "token_version", tokenVersion },
                 { "exp", DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds() },

--- a/src/web/src/app/actions/users.action.ts
+++ b/src/web/src/app/actions/users.action.ts
@@ -1,8 +1,7 @@
 "use server";
 
-import { apiFetch } from "@/lib/api";
+import { apiFetch, getAppToken } from "@/lib/api";
 import { CreateUserResponse, DefaultHttpResponse } from "@/types/http.types";
-import { getToken } from "@/lib/auth";
 
 interface ICreateUserData {
   checkbox: boolean;
@@ -19,9 +18,7 @@ type CreateUserAction = (
 
 export const createUserAction: CreateUserAction = async (data) => {
   try {
-    const AUTH_COOKIE_NAME = "auth-token";
-    const token = await getToken(AUTH_COOKIE_NAME);
-
+    const token = await getAppToken();
     const response = await apiFetch<DefaultHttpResponse<CreateUserResponse>>(
       "/users",
       "POST",


### PR DESCRIPTION
## Problema
Os endpoints de eventos usavam o e-mail como identificador no token JWT (campo `sub`). Se o usuário alterasse o e-mail, o token antigo passava a apontar para um e-mail inexistente no banco, quebrando todas as operações autenticadas.

## Solução
- O campo `sub` do token agora armazena o **ID** do usuário em vez do e-mail
- O e-mail continua no token como claim separado (para referência)
- Os serviços de eventos passaram a buscar o usuário por ID (`GetByIdAsync`) em vez de e-mail
- O logout também foi atualizado para buscar o usuário por ID ao invalidar o token

## Arquivos alterados
- `JwtService.cs` / `IJwtService.cs` — novo campo `userId` no `sub`
- `AuthService.cs` — passa `usr.Id` ao gerar token; logout busca por ID
- `EventsService.cs` / `IEventsService.cs` — métodos usam `organizerId`
- `EventsController.cs` — extrai `userId` do `sub`
- `users.action.ts` — registro usa `getAppToken()` em vez do cookie do usuário
