### PR TITLE
habilita edição e exclusão de eventos na tabela

### DIFF
--- a/src/web/src/app/(dashboard)/events/EventsTable.tsx
+++ b/src/web/src/app/(dashboard)/events/EventsTable.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Calendar, Edit, Trash2, Eye, Megaphone, PauseCircle, PlayCircle } from "lucide-react";
-import { pauseEventAction } from "@/actions/events.action";
+import { pauseEventAction, deleteEventAction } from "@/actions/events.action";
 import type { EventItem } from "./page";
 
 type Filter = "todos" | "publicados" | "encerrados";
@@ -81,6 +81,7 @@ export default function EventsTable({ events }: { events: EventItem[] }) {
   const [filter, setFilter] = useState<Filter>("todos");
   const [isPending, startTransition] = useTransition();
   const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const filtered = events.filter((e) => {
     const status = getVisualStatus(e);
@@ -101,6 +102,20 @@ export default function EventsTable({ events }: { events: EventItem[] }) {
       await pauseEventAction(event.id, event.status);
       router.refresh();
       setLoadingId(null);
+    });
+  }
+
+  function handleEdit(event: EventItem) {
+    router.push(`/events/new?id=${event.id}`);
+  }
+
+  function handleDeleteConfirm(id: string) {
+    setLoadingId(id);
+    startTransition(async () => {
+      await deleteEventAction(id);
+      router.refresh();
+      setLoadingId(null);
+      setConfirmDeleteId(null);
     });
   }
 
@@ -165,26 +180,53 @@ export default function EventsTable({ events }: { events: EventItem[] }) {
                     {event.participantsCount.toLocaleString("pt-BR")}
                   </td>
                   <td className="px-6 py-4">
-                    <div className="flex items-center gap-1">
-                      <span className="p-1.5 text-gray-200 cursor-not-allowed">
-                        <Edit size={15} />
-                      </span>
-                      <button
-                        onClick={() => handlePause(event)}
-                        disabled={isPast(event.date) || (isPending && loadingId === event.id)}
-                        className="p-1.5 text-gray-400 hover:text-yellow-500 transition-colors rounded disabled:opacity-30 disabled:cursor-not-allowed"
-                        title={event.status === "paused" ? "Publicar" : "Pausar"}
-                      >
-                        {event.status === "paused" ? (
-                          <PlayCircle size={15} />
-                        ) : (
-                          <PauseCircle size={15} />
-                        )}
-                      </button>
-                      <span className="p-1.5 text-gray-200 cursor-not-allowed">
-                        <Trash2 size={15} />
-                      </span>
-                    </div>
+                    {confirmDeleteId === event.id ? (
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-gray-500">Excluir?</span>
+                        <button
+                          onClick={() => handleDeleteConfirm(event.id)}
+                          disabled={isPending}
+                          className="text-xs font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
+                        >
+                          Sim
+                        </button>
+                        <button
+                          onClick={() => setConfirmDeleteId(null)}
+                          className="text-xs font-medium text-gray-500 hover:text-gray-700"
+                        >
+                          Não
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => handleEdit(event)}
+                          className="p-1.5 text-gray-400 hover:text-gray-700 transition-colors rounded"
+                          title="Editar"
+                        >
+                          <Edit size={15} />
+                        </button>
+                        <button
+                          onClick={() => handlePause(event)}
+                          disabled={isPast(event.date) || (isPending && loadingId === event.id)}
+                          className="p-1.5 text-gray-400 hover:text-yellow-500 transition-colors rounded disabled:opacity-30 disabled:cursor-not-allowed"
+                          title={event.status === "paused" ? "Publicar" : "Pausar"}
+                        >
+                          {event.status === "paused" ? (
+                            <PlayCircle size={15} />
+                          ) : (
+                            <PauseCircle size={15} />
+                          )}
+                        </button>
+                        <button
+                          onClick={() => setConfirmDeleteId(event.id)}
+                          className="p-1.5 text-gray-400 hover:text-red-500 transition-colors rounded"
+                          title="Excluir"
+                        >
+                          <Trash2 size={15} />
+                        </button>
+                      </div>
+                    )}
                   </td>
                 </tr>
               ))

--- a/src/web/src/app/(dashboard)/events/page.tsx
+++ b/src/web/src/app/(dashboard)/events/page.tsx
@@ -1,9 +1,5 @@
-"use client"
-
-import { apiFetch } from "@/lib/api";
+import { getMyEventsAction } from "@/actions/events.action";
 import EventsTable from "./EventsTable";
-import { useEffect, useState } from "react";
-import { useCookies } from "next-client-cookies";
 
 export type EventItem = {
   id: string;
@@ -15,35 +11,8 @@ export type EventItem = {
   status: string;
 };
 
-async function getMyEvents(token: string): Promise<EventItem[]> {
-  return apiFetch<EventItem[]>("/events/mine", "GET", undefined, token);
-}
-
-export default function EventsPage() {
-  const [myEvents, setMyEvents] = useState<EventItem[]>([]);
-  const cookies = useCookies();
-
-  useEffect(() => {
-    const loadEvents = async () => {
-      try {
-        const token = cookies.get("auth-token")
-
-        if (!token) {
-          setMyEvents([]);
-          return;
-        }
-
-        const events = await getMyEvents(token);
-
-        setMyEvents(events);
-      } catch (error) {
-        console.error(error);
-        setMyEvents([]);
-      }
-    };
-
-    loadEvents();
-  }, []);
+export default async function EventsPage() {
+  const myEvents = (await getMyEventsAction()) as EventItem[];
 
   return (
     <div className="max-w-5xl mx-auto px-8 py-8">

--- a/src/web/src/app/actions/events.action.ts
+++ b/src/web/src/app/actions/events.action.ts
@@ -105,3 +105,14 @@ export async function getEventByIdAction(id: string) {
 		return null;
 	}
 }
+
+export async function getMyEventsAction() {
+	const token = await getToken("auth-token");
+	if (!token) return [];
+
+	try {
+		return await apiFetch<Record<string, unknown>[]>("/events/mine", "GET", undefined, token);
+	} catch {
+		return [];
+	}
+}


### PR DESCRIPTION
Título do PR:


feat: habilitar edição e exclusão de eventos na tabela
Descrição:


## Resumo

- Habilita os botões de editar e excluir na tabela de eventos
- Ao clicar em excluir, exibe confirmação inline ("Excluir? Sim / Não") na linha da tabela
- Ao clicar em editar, redireciona para `/events/new?id=<id>` (página já suportava modo edição)
- Corrige o botão de pausar, que parou de funcionar após a página ser convertida para Client Component
- Adiciona `getMyEventsAction` para buscar eventos via Server Action, eliminando o import direto de `apiFetch` no Client Component

## Correções incluídas

- `events/page.tsx` revertido para Server Component, restaurando o `router.refresh()` após pausar/excluir
- `events.action.ts` com nova action `getMyEventsAction`